### PR TITLE
Added support for asymmetric input during training

### DIFF
--- a/scripts/train_mpii.py
+++ b/scripts/train_mpii.py
@@ -62,14 +62,14 @@ def main(args):
         logger.set_names(['Epoch', 'LR', 'Train Loss', 'Val Loss', 'Train Acc', 'Val Acc'])
 
     # create data loader
-    train_dataset = Mpii(args.image_path, is_train=True)
+    train_dataset = Mpii(args.image_path, is_train=True, inp_res=args.input_shape)
     train_loader = DataLoader(
         train_dataset,
         batch_size=args.train_batch, shuffle=True,
         num_workers=args.workers, pin_memory=True
     )
 
-    val_dataset = Mpii(args.image_path, is_train=False)
+    val_dataset = Mpii(args.image_path, is_train=False, inp_res=args.input_shape)
     val_loader = DataLoader(
         val_dataset,
         batch_size=args.test_batch, shuffle=False,
@@ -125,6 +125,8 @@ if __name__ == '__main__':
                         choices=['hg1', 'hg2', 'hg8'],
                         help='model architecture')
     # Training strategy
+    parser.add_argument('--input_shape', default=(256, 256), type=int, nargs='+',
+                        help='Input shape of the model. Given as: (H, W)')
     parser.add_argument('-j', '--workers', default=4, type=int, metavar='N',
                         help='number of data loading workers (default: 4)')
     parser.add_argument('--epochs', default=100, type=int, metavar='N',

--- a/src/stacked_hourglass/datasets/mpii.py
+++ b/src/stacked_hourglass/datasets/mpii.py
@@ -118,7 +118,7 @@ class Mpii(data.Dataset):
         for i in range(nparts):
             # if tpts[i, 2] > 0: # This is evil!!
             if tpts[i, 1] > 0:
-                tpts[i, 0:2] = to_torch(transform(tpts[i, 0:2]+1, c, s, [self.out_res, self.out_res], rot=r))
+                tpts[i, 0:2] = to_torch(transform(tpts[i, 0:2]+1, c, s, self.out_res, rot=r))
                 target[i], vis = draw_labelmap(target[i], tpts[i]-1, self.sigma, type=self.label_type)
                 target_weight[i, 0] *= vis
 

--- a/src/stacked_hourglass/datasets/mpii.py
+++ b/src/stacked_hourglass/datasets/mpii.py
@@ -35,12 +35,19 @@ class Mpii(data.Dataset):
     # Suggested joints to use for average PCK calculations.
     ACC_JOINTS = [0, 1, 2, 3, 4, 5, 10, 11, 14, 15]
 
-    def __init__(self, image_path, is_train=True, inp_res=256, out_res=64, sigma=1,
-                 scale_factor=0.25, rot_factor=30, label_type='Gaussian'):
+    # The ratio between input spatial resolution vs. output heatmap spatial resolution
+    INPUT_OUTPUT_RATIO = 4
+
+    def __init__(self, image_path, is_train=True, inp_res=256, sigma=1, scale_factor=0.25,
+                 rot_factor=30, label_type='Gaussian'):
         self.img_folder = image_path # root image folders
         self.is_train = is_train # training set or test set
-        self.inp_res = inp_res
-        self.out_res = out_res
+        if not isinstance(inp_res, (list, tuple)):  # Input res stored as (H, W)
+            self.inp_res = [inp_res, inp_res]
+        else:
+            self.inp_res = inp_res
+        self.out_res = [int(self.inp_res[0] / self.INPUT_OUTPUT_RATIO),
+                        int(self.inp_res[1] / self.INPUT_OUTPUT_RATIO)]
         self.sigma = sigma
         self.scale_factor = scale_factor
         self.rot_factor = rot_factor
@@ -100,12 +107,12 @@ class Mpii(data.Dataset):
             img[2, :, :].mul_(random.uniform(0.8, 1.2)).clamp_(0, 1)
 
         # Prepare image and groundtruth map
-        inp = crop(img, c, s, [self.inp_res, self.inp_res], rot=r)
+        inp = crop(img, c, s, self.inp_res, rot=r)
         inp = color_normalize(inp, self.DATA_INFO.rgb_mean, self.DATA_INFO.rgb_stddev)
 
         # Generate ground truth
         tpts = pts.clone()
-        target = torch.zeros(nparts, self.out_res, self.out_res)
+        target = torch.zeros(nparts, *self.out_res)
         target_weight = tpts[:, 2].clone().view(nparts, 1)
 
         for i in range(nparts):
@@ -116,6 +123,9 @@ class Mpii(data.Dataset):
                 target_weight[i, 0] *= vis
 
         # Meta info
+        if not isinstance(s, torch.Tensor):
+            s = torch.Tensor(s)
+
         meta = {'index' : index, 'center' : c, 'scale' : s,
         'pts' : pts, 'tpts' : tpts, 'target_weight': target_weight}
 

--- a/src/stacked_hourglass/utils/transforms.py
+++ b/src/stacked_hourglass/utils/transforms.py
@@ -41,12 +41,16 @@ def get_transform(center, scale, res, rot=0):
     """
     General image processing functions
     """
+    if not isinstance(scale, (list, torch.Tensor)):
+        scale = [scale, scale]
+
     # Generate transformation matrix
-    h = 200 * scale
+    h = 200 * scale[0]
+    w = 200 * scale[1]
     t = np.zeros((3, 3))
-    t[0, 0] = float(res[1]) / h
+    t[0, 0] = float(res[1]) / w
     t[1, 1] = float(res[0]) / h
-    t[0, 2] = res[1] * (-float(center[0]) / h + .5)
+    t[0, 2] = res[1] * (-float(center[0]) / w + .5)
     t[1, 2] = res[0] * (-float(center[1]) / h + .5)
     t[2, 2] = 1
     if not rot == 0:
@@ -78,38 +82,48 @@ def transform(pt, center, scale, res, invert=0, rot=0):
 
 
 def transform_preds(coords, center, scale, res):
-    # size = coords.size()
-    # coords = coords.view(-1, coords.size(-1))
-    # print(coords.size())
     for p in range(coords.size(0)):
         coords[p, 0:2] = to_torch(transform(coords[p, 0:2], center, scale, res, 1, 0))
     return coords
 
 
 def crop(img, center, scale, res, rot=0):
+    """
+    img: torch.Tensor: shape: C,H,W
+    center: torch.Tensor: shape: x, y
+    scale: [H/200, W/200]
+    res: H,W
+    """
+    if not isinstance(scale, (list, torch.Tensor)):
+        scale = [scale, scale]
+
     img = im_to_numpy(img)
 
     # Preprocessing for efficient cropping
     ht, wd = img.shape[0], img.shape[1]
-    sf = scale * 200.0 / res[0]
-    if sf < 2:
-        sf = 1
+    # If we set the scale properly at input, then this should be the same per-dimension
+    sf = [scale[0] * 200.0 / res[0], scale[1] * 200.0 / res[1]]
+
+    # NOTE: This seems to be handled, but is untested
+    if sf[0] < 2 or sf[1] < 2:
+        sf = [1, 1]
     else:
-        new_size = int(np.math.floor(max(ht, wd) / sf))
-        new_ht = int(np.math.floor(ht / sf))
-        new_wd = int(np.math.floor(wd / sf))
-        if new_size < 2:
+        new_size = int(np.math.floor(max(ht, wd) / sf[0]))
+        new_ht = int(np.math.floor(ht / sf[0]))
+        new_wd = int(np.math.floor(wd / sf[1]))
+        if new_size < 2:    # This returns a fully black image...
             return torch.zeros(res[0], res[1], img.shape[2]) \
                         if len(img.shape) > 2 else torch.zeros(res[0], res[1])
         else:
             img = imresize(img, [new_ht, new_wd])
-            center = center * 1.0 / sf
-            scale = scale / sf
+            center = center * 1.0 / torch.tensor(sf[::-1])  # Center is x, y. Sf is H,W
+            scale = [scale[0] / sf[0], scale[1] / sf[1]]
 
     # Upper left point
     ul = np.array(transform([0, 0], center, scale, res, invert=1))
     # Bottom right point
-    br = np.array(transform(res, center, scale, res, invert=1))
+    # NOTE: res stored as H, W. We want coordinates in x, y
+    br = np.array(transform(res[::-1], center, scale, res, invert=1))
 
     # Padding so that when rotated proper amount of context is included
     pad = int(np.linalg.norm(br - ul) / 2 - float(br[1] - ul[1]) / 2)

--- a/src/stacked_hourglass/utils/transforms.py
+++ b/src/stacked_hourglass/utils/transforms.py
@@ -41,6 +41,10 @@ def get_transform(center, scale, res, rot=0):
     """
     General image processing functions
     """
+    # If given 1D scale as a torch Tensor, convert to a pair of scales
+    if isinstance(scale, torch.Tensor) and scale.ndim == 0:
+        scale = [scale, scale]
+
     if not isinstance(scale, (list, torch.Tensor)):
         scale = [scale, scale]
 
@@ -94,6 +98,10 @@ def crop(img, center, scale, res, rot=0):
     scale: [H/200, W/200]
     res: H,W
     """
+    # If given 1D scale as a torch Tensor, convert to a pair of scales
+    if isinstance(scale, torch.Tensor) and scale.ndim == 0:
+        scale = [scale, scale]
+
     if not isinstance(scale, (list, torch.Tensor)):
         scale = [scale, scale]
 

--- a/src/stacked_hourglass/utils/transforms.py
+++ b/src/stacked_hourglass/utils/transforms.py
@@ -41,12 +41,9 @@ def get_transform(center, scale, res, rot=0):
     """
     General image processing functions
     """
-    # If given 1D scale as a torch Tensor, convert to a pair of scales
-    if isinstance(scale, torch.Tensor) and scale.ndim == 0:
-        scale = [scale, scale]
-
-    if not isinstance(scale, (list, torch.Tensor)):
-        scale = [scale, scale]
+    scale = np.asarray(scale).flatten()
+    if len(scale) == 1:
+        scale = scale.repeat(2)
 
     # Generate transformation matrix
     h = 200 * scale[0]
@@ -98,12 +95,9 @@ def crop(img, center, scale, res, rot=0):
     scale: [H/200, W/200]
     res: H,W
     """
-    # If given 1D scale as a torch Tensor, convert to a pair of scales
-    if isinstance(scale, torch.Tensor) and scale.ndim == 0:
-        scale = [scale, scale]
-
-    if not isinstance(scale, (list, torch.Tensor)):
-        scale = [scale, scale]
+    scale = np.asarray(scale).flatten()
+    if len(scale) == 1:
+        scale = scale.repeat(2)
 
     img = im_to_numpy(img)
 


### PR DESCRIPTION
Adding support for training a model using asymmetric input.
I've updated the existing transform code to be consistent with the usage of X/Y, height/width.
I've also decoupled the scale into height and width components and updated the code respectively.

I've tested this on the MPII dataset as input, and visually observed that the target heatmaps correctly line up with the input images for both symmetric and asymmetric input. Additionally, I've tested leaving the input resolution as it was (256x256), and observed that the heatmaps again are as expected.

Two notes:

- The MPII dataloader need to know the output heatmap resolution to construct the target heatmaps. Historically, this was given as an argument to the constructor, but likely was never manually specified. The output resolution is driven by the striding of the model, hence there should only be 1x valid output resolution per-input resolution. I've currently defined a constant to reflect the ratio between input/output resolution, however there may be other ways to solve this. One method would be to let the user specify the output resolution (or perhaps even the input-output resolution relationship).

- On line 116 of transforms.py, there was a check for a scale factor < 2. Given the scale is now decoupled between width and height, I've added a corresponding condition, however I'm uncertain what this is actually checking for, so I haven't tested if the replacement condition functions as expected.